### PR TITLE
Update jefreg.php

### DIFF
--- a/plugins/system/jefreg/jefreg.php
+++ b/plugins/system/jefreg/jefreg.php
@@ -134,7 +134,7 @@ class PlgSystemJefreg extends JPlugin
 		$jefreg = $this->getJEFReg();
 		
 		// Use JFormRuleUrl to check if $_POST['installat'] is valid URL
-		$field = new SimpleXMLElement('<field></field>');
+		$field = new SimpleXMLElement('<field required="true"></field>');
 		$rule = new JFormRuleUrl;
 		return $rule->test($field, $jefreg['installat']) &&
 			$this->getInstallFrom($jefreg['installapp']);


### PR DESCRIPTION
You must set the field as required. If the field is not required when $jefreg['installat'] is empty, the rule test for the field will return as true (i.e. valid), instead of false.
